### PR TITLE
Added option to download a file directly into a stream

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -110,7 +110,7 @@ class Process extends ApiObject
      * @throws \GuzzleHttp\Exception if there is a general HTTP / network error
      *
      */
-    public function get($stream, $remotefile = null)
+    public function downloadStream($stream, $remotefile = null)
     {
         if (!isset($this->output->url)) {
             throw new Exceptions\ApiException("There is no output file available (yet)", 400);

--- a/src/Process.php
+++ b/src/Process.php
@@ -78,15 +78,11 @@ class Process extends ApiObject
      *
      * @throws \CloudConvert\Exceptions\ApiException if the CloudConvert API returns an error
      * @throws \GuzzleHttp\Exception if there is a general HTTP / network error
-     * ª@throws Exceptions\InvalidParameterException
+     * @throws Exceptions\InvalidParameterException
      *
      */
     public function download($localfile = null, $remotefile = null)
     {
-        if (!isset($this->output->url)) {
-            throw new Exceptions\ApiException("There is no output file available (yet)", 400);
-        }
-
         if (isset($localfile) && is_dir($localfile) && isset($this->output->filename)) {
             $localfile = realpath($localfile) . DIRECTORY_SEPARATOR
                 . (isset($remotefile) ? $remotefile : $this->output->filename);
@@ -98,7 +94,29 @@ class Process extends ApiObject
             throw new Exceptions\InvalidParameterException("localfile parameter is not set correctly");
         }
 
-        $local = Stream::factory(fopen($localfile, 'w'));
+        return $this->get(fopen($localfile, 'w'), $remotefile);
+    }
+
+    /**
+     * Download process files from API and write to a given stream
+     *
+     * @param resource $stream Stream to write the downloaded data to
+     * @param string $remotefile Remote file name which should be downloaded (if there are
+     *         multiple output files available)
+     *
+     * @return \CloudConvert\Process
+     *
+     * @throws \CloudConvert\Exceptions\ApiException if the CloudConvert API returns an error
+     * @throws \GuzzleHttp\Exception if there is a general HTTP / network error
+     *
+     */
+    public function get($stream, $remotefile = null)
+    {
+        if (!isset($this->output->url)) {
+            throw new Exceptions\ApiException("There is no output file available (yet)", 400);
+        }
+
+        $local = Stream::factory($stream);
         $download = $this->api->get($this->output->url . (isset($remotefile) ? '/' . $remotefile : ''), false, false);
         $local->write($download);
         return $this;


### PR DESCRIPTION
Hi there,

previously you could download the converted file only to a file, now you can also write the data directly into an in-memory stream and process the data further.