### PR TITLE
Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 before_script:
   - composer install
 script: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "psr/http-message": "^1.0",
     "php-http/client-implementation": "^1.0 || ^2.0",
     "php-http/httplug": "^1.0 || ^2.0",
     "php-http/message-factory": "^1.0",
     "php-http/discovery": "^1.0",
     "symfony/options-resolver": "^4.2 || ^5.0",
-    "netresearch/jsonmapper": "^1.6",
+    "netresearch/jsonmapper": "^4.0",
     "php-http/multipart-stream-builder": "^1.0",
     "php-http/client-common": "^2.0",
     "php-http/message": "^1.7",
@@ -25,7 +25,7 @@
   "require-dev": {
     "php-http/mock-client": "^1.0",
     "guzzlehttp/guzzle": "^7.0",
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^7.0 || ^9.3"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,8 @@
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>
-        <testsuite name="integration">
-            <directory>tests/integration</directory>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
     <php>

--- a/src/Hydrator/JsonMapperHydrator.php
+++ b/src/Hydrator/JsonMapperHydrator.php
@@ -90,8 +90,7 @@ class JsonMapperHydrator implements HydratorInterface
      */
     public function createObjectByResponse(string $class, ResponseInterface $response)
     {
-        $body = json_decode($response->getBody());
-        return $this->hydrateObjectByResponse($this->jsonMapper->createInstance($class, false, $body->data), $response);
+        return $this->hydrateObjectByResponse(new $class, $response);
     }
 
 

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -85,9 +85,10 @@ class Task
     /**
      * Task constructor.
      *
-     * @param string $name
+     * @param string|null $operation
+     * @param string|null $name
      */
-    public function __construct(string $operation, string $name)
+    public function __construct(string $operation = null, string $name = null)
     {
         $this->operation = $operation;
         $this->name = $name;

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected $cloudConvert;
 
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->cloudConvert = new CloudConvert([

--- a/tests/Unit/TaskResourceTest.php
+++ b/tests/Unit/TaskResourceTest.php
@@ -174,8 +174,8 @@ class TaskResourceTest extends TestCase
                 $body = (string)$request->getBody();
 
                 foreach ((array)$task->getResult()->form->parameters as $parameter => $value) {
-                    $this->assertContains('name="' . $parameter . '"', $body);
-                    $this->assertContains((string)$value, $body);
+                    $this->assertStringContainsString('name="' . $parameter . '"', $body);
+                    $this->assertStringContainsString((string)$value, $body);
                 }
 
                 return true;

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected $mockClient;
 
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->cloudConvert = new CloudConvert([
@@ -42,6 +42,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         return $this->mockClient;
 
+    }
+
+    /**
+     * The method is here to provice BC compatibility with PHPUnit >= 9 where this method was removed.
+     *
+     * @param string $regex
+     */
+    public function expectExceptionMessageRegExp(string $regex): void
+    {
+        if (!method_exists($this, 'expectExceptionMessageMatches')) {
+            parent::expectExceptionMessageRegExp($regex);
+
+            return;
+        }
+
+        $this->expectExceptionMessageMatches($regex);
     }
 
 }


### PR DESCRIPTION
This required updating `netresearch/jsonmapper` and noticed `createInstance` was used, this was not intended to be public and was changed to protected later, looking at what it did it made no sense, it was just to create a instance of the class without calling the constructor, which seems like a pretty bad thing to do, so I've changed the constructor why this was here in the first place and now we're all good and also not decoding the JSON response twice (some more discussion about this: https://github.com/cweiske/jsonmapper/issues/140).

I also needed to add a method to support PHPUnit 7 & 9. It can be cleanup up a lot if you are willing to drop support for some php version since only 7.3 and up is still supported: https://www.php.net/supported-versions.php.

For the rest this was pretty straight forward.

Waiting for Travis CI to trigger a build, tested this only on 7.2 and 8.0 locally since there is no easy way for me to run PHP 7.1 locally. Re-triggered the build by opening/closing, sorry about the notification from that!