### PR TITLE
fix(import/upload): a dummy filename must be provided when POSTing a raw string as a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $cloudconvert->jobs()->create($job);
 
 $uploadTask = $job->getTasks()->whereName('upload-my-file')[0];
 
-$cloudconvert->tasks()->upload($uploadTask, fopen('./file.pdf', 'r'));
+$cloudconvert->tasks()->upload($uploadTask, fopen('./file.pdf', 'r'), 'file.pdf');
 ```
 The `upload()` method accepts a string, PHP resource or PSR-7 `StreamInterface` as second parameter.
 

--- a/src/Resources/TasksResource.php
+++ b/src/Resources/TasksResource.php
@@ -94,10 +94,11 @@ class TasksResource extends AbstractResource
     /**
      * @param Task                            $task
      * @param string|resource|StreamInterface $file
+     * @param string                          $fileName
      *
      * @return ResponseInterface
      */
-    public function upload(Task $task, $file): ResponseInterface
+    public function upload(Task $task, $file, string $fileName): ResponseInterface
     {
         if ($task->getOperation() !== 'import/upload') {
             throw new \BadMethodCallException('The task operation is not import/upload');
@@ -108,7 +109,7 @@ class TasksResource extends AbstractResource
             throw new \BadMethodCallException('The task is not ready for uploading');
         }
         $form = $task->getResult()->form;
-        return $this->httpTransport->upload($form->url, $file, (array)$form->parameters ?? []);
+        return $this->httpTransport->upload($form->url, $file, $fileName, (array)$form->parameters ?? []);
     }
 
 }

--- a/src/Resources/TasksResource.php
+++ b/src/Resources/TasksResource.php
@@ -94,11 +94,11 @@ class TasksResource extends AbstractResource
     /**
      * @param Task                            $task
      * @param string|resource|StreamInterface $file
-     * @param string                          $fileName
+     * @param string|null                     $fileName
      *
      * @return ResponseInterface
      */
-    public function upload(Task $task, $file, string $fileName): ResponseInterface
+    public function upload(Task $task, $file, string $fileName = null): ResponseInterface
     {
         if ($task->getOperation() !== 'import/upload') {
             throw new \BadMethodCallException('The task operation is not import/upload');

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -178,17 +178,18 @@ class HttpTransport
     /**
      * @param                                 $path
      * @param string|resource|StreamInterface $file
+     * @param string                          $fileName
      * @param array                           $additionalParameters
      *
      * @return ResponseInterface
      */
-    public function upload($path, $file, array $additionalParameters = []): ResponseInterface
+    public function upload($path, $file, string $fileName, array $additionalParameters = []): ResponseInterface
     {
         $builder = new MultipartStreamBuilder($this->getStreamFactory());
         foreach ($additionalParameters as $parameter => $value) {
             $builder->addResource($parameter, strval($value));
         }
-        $builder->addResource('file', $file);
+        $builder->addResource('file', $file, ['filename' => $fileName]);
 
         $multipartStream = $builder->build();
         $boundary = $builder->getBoundary();

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -178,18 +178,23 @@ class HttpTransport
     /**
      * @param                                 $path
      * @param string|resource|StreamInterface $file
-     * @param string                          $fileName
+     * @param string|null                     $fileName
      * @param array                           $additionalParameters
      *
      * @return ResponseInterface
      */
-    public function upload($path, $file, string $fileName, array $additionalParameters = []): ResponseInterface
+    public function upload($path, $file, string $fileName = null, array $additionalParameters = []): ResponseInterface
     {
         $builder = new MultipartStreamBuilder($this->getStreamFactory());
         foreach ($additionalParameters as $parameter => $value) {
             $builder->addResource($parameter, strval($value));
         }
-        $builder->addResource('file', $file, ['filename' => $fileName]);
+
+        $resourceOptions = [];
+        if($fileName === null) {
+            $resourceOptions['filename'] = $fileName;
+        }
+        $builder->addResource('file', $file, $resourceOptions);
 
         $multipartStream = $builder->build();
         $boundary = $builder->getBoundary();

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -191,7 +191,7 @@ class HttpTransport
         }
 
         $resourceOptions = [];
-        if($fileName === null) {
+        if($fileName !== null) {
             $resourceOptions['filename'] = $fileName;
         }
         $builder->addResource('file', $file, $resourceOptions);


### PR DESCRIPTION
This commit adds an optional `string $fileName` parameter to `TasksResource::upload()` in order to allow providing a file name when uploading (task 'import/upload') a file from a raw string. In such cases, no file name can be retreived from the underlying stream or file, whereas the back-end expects (seems to expect) a valid file name.

This approach matches the one used in [the node version](https://github.com/cloudconvert/cloudconvert-node/blob/master/lib/TasksResource.ts#L452).

---

The endpoint generated by the import/upload task seems to expect a "filename" for the file being uploaded.

Test case:

    $cloudConvert = new CloudConvert(...);

    $uploadTask = new Task('import/upload', 'import-task');
    $job = (new Job())->addTask($uploadTask);
    $cloudConvert->jobs()->create($job);

    $plainString = 'Hello World';
    $cloudConvert->tasks()->upload($uploadTask, $plainString);

Response: (see Task 683ee4b8-59d5-4caa-913d-d97f4eec4c47) 

    {
        "files": [
            {
                "filename": "${filename}",
                "md5": "___redacted___"
            }
        ]
    }

Notice the "${filename}" string, this invalid name is probably used as is in subsequent tasks. A HTML-to-DOCX conversion, based on this import, will fail (see Job 63d0840f-99eb-415e-8388-0f489e6fd66f).

`\Http\Message\MultipartStream\MultipartStreamBuilder::addResource()` (as called from [`HttpTransport::upload()`](https://github.com/cloudconvert/cloudconvert-php/blob/master/src/Transport/HttpTransport.php#L191)) is able to [retreive the underlying file name from the StreamInterface or the File resource](https://github.com/php-http/multipart-stream-builder/blob/1.1.2/src/MultipartStreamBuilder.php#L97), but of course not when passing a raw string.
