### PR TITLE
Update allowed http type to include correct PSR interface.

### DIFF
--- a/src/CloudConvert.php
+++ b/src/CloudConvert.php
@@ -10,6 +10,7 @@ use CloudConvert\Resources\TasksResource;
 use CloudConvert\Resources\UsersResource;
 use CloudConvert\Transport\HttpTransport;
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CloudConvert
@@ -56,7 +57,7 @@ class CloudConvert
         $resolver->setAllowedTypes('sandbox', 'boolean');
 
         $resolver->setDefined('http_client');
-        $resolver->setAllowedTypes('http_client', HttpClient::class);
+        $resolver->setAllowedTypes('http_client', [HttpClient::class, ClientInterface::class]);
 
     }
 


### PR DESCRIPTION
The configuration for the option resolver points to an outdated Httplug class `Http\Client\HttpClient`.  

CloudConvert's `HttpTransport` class uses `Psr18ClientDiscovery::find()` which creates an instance of `Psr18Client`.  

Psr18Client does not implement `Http\Client\HttpClient`; it implements `Psr\Http\Client\ClientInterface`.

This modification is required to allow users to override the HttpClient with an alternative configuration.