### PR TITLE
Add support for guzzle/psr7 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0",
     "php-http/client-common": "^2.0",
     "php-http/message": "^1.7",
-    "guzzlehttp/psr7": "^1.0"
+    "guzzlehttp/psr7": "^1.0 || ^2.0"
   },
   "require-dev": {
     "php-http/mock-client": "^1.0",


### PR DESCRIPTION
A small change in composer.json in order to support guzzle/psr7 2.1.0

I ran the unit test suite and there didn't seem to be any issues.