### PR TITLE
Jobs: add webhook URL

### DIFF
--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -23,6 +23,11 @@ class Job
     protected $tag;
 
     /**
+     * @var string|null
+     */
+    protected $webhook_url;
+
+    /**
      * @var \DateTimeImmutable
      */
     protected $created_at;
@@ -77,6 +82,22 @@ class Job
     {
         $this->tag = $tag;
         return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWebhookUrl(): ?string
+    {
+        return $this->webhook_url;
+    }
+
+    /**
+     * @param string|null $webhook_url
+     */
+    public function setWebhookUrl(?string $webhook_url): void
+    {
+        $this->webhook_url = $webhook_url;
     }
 
     /**

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -95,9 +95,10 @@ class Job
     /**
      * @param string|null $webhook_url
      */
-    public function setWebhookUrl(?string $webhook_url): void
+    public function setWebhookUrl(?string $webhook_url): Job
     {
         $this->webhook_url = $webhook_url;
+        return $this;
     }
 
     /**

--- a/src/Resources/JobsResource.php
+++ b/src/Resources/JobsResource.php
@@ -52,8 +52,9 @@ class JobsResource extends AbstractResource
             );
         }
         $response = $this->httpTransport->post($this->httpTransport->getBaseUri() . '/jobs', [
-            'tasks' => $tasks,
-            'tag'   => $job->getTag()
+            'tasks'       => $tasks,
+            'tag'         => $job->getTag(),
+            'webhook_url' => $job->getWebhookUrl()
         ]);
         return $this->hydrator->hydrateObjectByResponse($job, $response);
     }
@@ -68,7 +69,8 @@ class JobsResource extends AbstractResource
      */
     public function refresh(Job $job, $query = null): Job
     {
-        $response = $this->httpTransport->get($this->httpTransport->getBaseUri() . '/jobs/' . $job->getId(), $query ?? []);
+        $response = $this->httpTransport->get($this->httpTransport->getBaseUri() . '/jobs/' . $job->getId(),
+            $query ?? []);
         return $this->hydrator->hydrateObjectByResponse($job, $response);
     }
 


### PR DESCRIPTION
Allow setting a webhook URL for the current job:

```php
$job = (new Job())
    ->setWebhookUrl('https://myendpoint')
    ->addTask(
         ...
    );
```

Replaces #88 