### PR TITLE
Update the syntax of the MIT license name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The License (MIT)
+MIT License
 
 Copyright (c) 2017 Josias Montag <josias@montag.info>
 


### PR DESCRIPTION
I'm finding that our automated license lister, https://github.com/Comcast/php-legal-licenses/, doesn't recognize the license on this project. For example:
```
centraldesktop/protobuf-php@1.0.1 [MIT]
cloudconvert/cloudconvert-php@3.2.1 [Not configured.]
clue/socket-raw@v1.4.1 [MIT]

```
I'm thinking it might be due to the way the name is stated. I'm proposing updating it to be the same as in a repo where the license is currently recognized.