### PR TITLE
Fix PHP 8.4 deprecations: make implicitly nullable parameters explicit

### DIFF
--- a/src/Handler/SignedUrlBuilder.php
+++ b/src/Handler/SignedUrlBuilder.php
@@ -8,7 +8,7 @@ class SignedUrlBuilder
 {
 
 
-    public function createFromJob(string $base, string $signingSecret, Job $job, string $cacheKey = null): string
+    public function createFromJob(string $base, string $signingSecret, Job $job, ?string $cacheKey = null): string
     {
 
         $json = json_encode($job->getPayload());

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -88,7 +88,7 @@ class Task
      * @param string|null $operation
      * @param string|null $name
      */
-    public function __construct(string $operation = null, string $name = null)
+    public function __construct(?string $operation = null, ?string $name = null)
     {
         $this->operation = $operation;
         $this->name = $name;

--- a/src/Resources/TasksResource.php
+++ b/src/Resources/TasksResource.php
@@ -98,7 +98,7 @@ class TasksResource extends AbstractResource
      *
      * @return ResponseInterface
      */
-    public function upload(Task $task, $file, string $fileName = null): ResponseInterface
+    public function upload(Task $task, $file, ?string $fileName = null): ResponseInterface
     {
         if ($task->getOperation() !== 'import/upload') {
             throw new \BadMethodCallException('The task operation is not import/upload');

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -207,7 +207,7 @@ class HttpTransport
      *
      * @return ResponseInterface
      */
-    public function upload($path, $file, string $fileName = null, array $additionalParameters = []): ResponseInterface
+    public function upload($path, $file, ?string $fileName = null, array $additionalParameters = []): ResponseInterface
     {
         $builder = new MultipartStreamBuilder($this->getStreamFactory());
         foreach ($additionalParameters as $parameter => $value) {


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters (e.g. `function foo(string $x = null)`).
Prevents PHP 8.4 deprecation warnings like:
"Implicitly marking parameter $x as nullable is deprecated, the explicit nullable type must be used instead"